### PR TITLE
Revert 7549bfa and restore preorder query clause behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 1.3.0
 
 - Added support for post search
+- Added setting for possible preorder text in search results
 
 ## Version 1.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 1.3.0
+
+- Added support for post search
+
 ## Version 1.2.2
 
 - Fixed bug with the preorder text not showing in cart and checkout page

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Netivo Module for WooCommerce to add preorder option to products",
   "minimum-stability": "stable",
   "license": "proprietary",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "authors": [
     {
       "name": "netivo",

--- a/src/Admin/Settings.php
+++ b/src/Admin/Settings.php
@@ -85,6 +85,16 @@ class Settings {
 		);
 
 		$settings[] = array(
+			'title'    => __( 'Dodatkowe frazy wyszukiwania', 'netivo' ),
+			'id'       => 'nt_preorder_search_terms',
+			'type'     => 'textarea',
+			'default'  => '',
+			'desc'     => __( 'Dodatkowe frazy (każda w nowej linii), po których produkty z preorderem będą wyszukiwane.', 'netivo' ),
+			'desc_tip' => true,
+			'css'      => 'min-width:300px;min-height:100px;'
+		);
+
+		$settings[] = array(
 			'type' => 'sectionend',
 			'id'   => 'nt_preorder_settings'
 		);

--- a/src/Product.php
+++ b/src/Product.php
@@ -2,6 +2,8 @@
 
 namespace Netivo\Module\WooCommerce\ProductPreorder;
 
+use WP_Query;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	header( 'HTTP/1.0 403 Forbidden' );
 	exit;
@@ -14,10 +16,39 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Product {
 
+	private string $text;
+	private string $position;
+
+	/**
+	 * Product constructor.
+	 *
+	 * Initializes filters and actions.
+	 */
 	public function __construct() {
+		$this->text     = get_option( 'nt_preorder_text', '[PREORDER]' );
+		$this->position = get_option( 'nt_preorder_position', 'before' );
+		$this->init_filters();
+		$this->init_actions();
+	}
+
+	/**
+	 * Initializes filters related to preorder titles.
+	 *
+	 * @return void
+	 */
+	protected function init_filters(): void {
 		add_filter( 'the_title', [ $this, 'nt_preorder_title' ], 10, 2 );
 		add_filter( 'woocommerce_cart_item_name', [ $this, 'nt_preorder_title' ], 10, 2 );
 		add_filter( 'woocommerce_order_item_get_name', [ $this, 'nt_preorder_title' ], 10, 2 );
+		add_filter( 'posts_clauses', [ $this, 'modify_preorder_posts_clauses' ], 10, 2 );
+	}
+
+	/**
+	 * Initializes actions related to preorder queries.
+	 *
+	 * @return void
+	 */
+	protected function init_actions(): void {
 	}
 
 	/**
@@ -36,17 +67,66 @@ class Product {
 		} else {
 			$post_id = $post;
 		}
-		if ( get_post_meta( $post_id, '_nt_preorder', true ) == 'yes' ) {
-			$text     = get_option( 'nt_preorder_text', '[PREORDER]' );
-			$position = get_option( 'nt_preorder_position', 'before' );
+		if ( get_post_meta( $post_id, '_nt_preorder', true ) === 'yes' ) {
 
-			if ( $position == 'before' ) {
-				$title = $text . ' ' . $title;
-			} else if ( $position == 'after' ) {
-				$title = $title . ' ' . $text;
+			if ( $this->position === 'before' ) {
+				$title = $this->text . ' ' . $title;
+			} else if ( $this->position === 'after' ) {
+				$title = $title . ' ' . $this->text;
 			}
 		}
 
 		return $title;
+	}
+
+	/**
+	 * Modifies the product query clauses to filter by preorder meta if search term matches.
+	 *
+	 * @param array $clauses
+	 * @param WP_Query $query
+	 *
+	 * @return array
+	 */
+	public function modify_preorder_posts_clauses( array $clauses, WP_Query $query ): array {
+		if ( is_admin() || ! $query->is_main_query() || ! $query->is_post_type_archive( 'product' ) ) {
+			return $clauses;
+		}
+
+		$search_query = $query->get( 's' );
+
+		if ( empty( $search_query ) ) {
+			return $clauses;
+		}
+
+		$search_terms = $this->get_preorder_search_terms();
+
+		if ( in_array( strtolower( trim( $search_query ) ), array_unique( $search_terms ), true ) ) {
+			global $wpdb;
+
+			// Join with postmeta to filter by _nt_preorder
+			$clauses['join'] .= " LEFT JOIN {$wpdb->postmeta} AS nt_pm ON ({$wpdb->posts}.ID = nt_pm.post_id AND nt_pm.meta_key = '_nt_preorder') ";
+
+			// Force the where clause to only include preorder products and ignore the standard search 's' for where clause
+			// We keep 's' in the query object so breadcrumbs and titles work automatically
+			$clauses['where'] = " AND nt_pm.meta_value = 'yes' AND {$wpdb->posts}.post_type = 'product' AND {$wpdb->posts}.post_status = 'publish' ";
+		}
+
+		return $clauses;
+	}
+
+	/**
+	 * Returns an array of search terms that should trigger the preorder filter.
+	 *
+	 * @return array
+	 */
+	protected function get_preorder_search_terms(): array {
+		return [
+			'przedsprzedaz',
+			'przedsprzedaż',
+			'preorder',
+			'pre order',
+			strtolower( trim( $this->text ) ),
+			strtolower( trim( str_replace( [ '[', ']' ], '', $this->text ) ) ),
+		];
 	}
 }

--- a/src/Product.php
+++ b/src/Product.php
@@ -93,16 +93,12 @@ class Product {
 			return $clauses;
 		}
 		global $wpdb;
+		$meta_key   = esc_sql( '_nt_preorder' );
+		$meta_value = esc_sql( 'yes' );
 
 		// Join with postmeta to filter by _nt_preorder
-		$clauses['join'] .= $wpdb->prepare(
-			" LEFT JOIN {$wpdb->postmeta} AS nt_preorder_pm ON ({$wpdb->posts}.ID = nt_preorder_pm.post_id AND nt_preorder_pm.meta_key = %s) ",
-			'_nt_preorder'
-		);
-		$clauses['where'] .= $wpdb->prepare(
-			" AND nt_preorder_pm.meta_value = %s ",
-			'yes'
-		);
+		$clauses['join'] .= " INNER JOIN {$wpdb->postmeta} AS nt_preorder_pm ON ({$wpdb->posts}.ID = nt_preorder_pm.post_id AND nt_preorder_pm.meta_key = '{$meta_key}') ";
+		$clauses['where'] .= " AND nt_preorder_pm.meta_value = '{$meta_value}' ";
 
 		return $clauses;
 	}

--- a/src/Product.php
+++ b/src/Product.php
@@ -88,7 +88,7 @@ class Product {
 	 * @return array
 	 */
 	public function modify_preorder_posts_clauses( array $clauses, WP_Query $query ): array {
-		if ( is_admin() || ! $query->is_main_query() || ! $query->is_post_type_archive( 'product' ) ) {
+		if ( is_admin() || ! $query->is_main_query() || ! is_post_type_archive( 'product' ) ) {
 			return $clauses;
 		}
 
@@ -104,11 +104,11 @@ class Product {
 			global $wpdb;
 
 			// Join with postmeta to filter by _nt_preorder
-			$clauses['join'] .= " LEFT JOIN {$wpdb->postmeta} AS nt_pm ON ({$wpdb->posts}.ID = nt_pm.post_id AND nt_pm.meta_key = '_nt_preorder') ";
+			$clauses['join'] .= " LEFT JOIN {$wpdb->postmeta} AS nt_preorder_pm ON ({$wpdb->posts}.ID = nt_preorder_pm.post_id AND nt_preorder_pm.meta_key = '_nt_preorder') ";
 
 			// Force the where clause to only include preorder products and ignore the standard search 's' for where clause
 			// We keep 's' in the query object so breadcrumbs and titles work automatically
-			$clauses['where'] = " AND nt_pm.meta_value = 'yes' AND {$wpdb->posts}.post_type = 'product' AND {$wpdb->posts}.post_status = 'publish' ";
+			$clauses['where'] .= " OR nt_preorder_pm.meta_value = 'yes' ";
 		}
 
 		return $clauses;

--- a/src/Product.php
+++ b/src/Product.php
@@ -100,7 +100,7 @@ class Product {
 
 		$search_terms = $this->get_preorder_search_terms();
 
-		if ( in_array( strtolower( trim( $search_query ) ), array_unique( $search_terms ), true ) ) {
+		if ( in_array( strtolower( trim( $search_query ) ), $search_terms, true ) ) {
 			global $wpdb;
 
 			// Join with postmeta to filter by _nt_preorder
@@ -120,7 +120,7 @@ class Product {
 	 * @return array
 	 */
 	protected function get_preorder_search_terms(): array {
-		return [
+		$terms = [
 			'przedsprzedaz',
 			'przedsprzedaż',
 			'preorder',
@@ -128,5 +128,19 @@ class Product {
 			strtolower( trim( $this->text ) ),
 			strtolower( trim( str_replace( [ '[', ']' ], '', $this->text ) ) ),
 		];
+
+		$additional_terms = get_option( 'nt_preorder_search_terms', '' );
+
+		if ( ! empty( $additional_terms ) ) {
+			$additional_terms_array = explode( "\n", str_replace( "\r", '', $additional_terms ) );
+			foreach ( $additional_terms_array as $term ) {
+				$term = strtolower( trim( $term ) );
+				if ( ! empty( $term ) ) {
+					$terms[] = $term;
+				}
+			}
+		}
+
+		return array_unique( $terms );
 	}
 }

--- a/src/Product.php
+++ b/src/Product.php
@@ -93,12 +93,16 @@ class Product {
 			return $clauses;
 		}
 		global $wpdb;
-		$meta_key   = esc_sql( '_nt_preorder' );
-		$meta_value = esc_sql( 'yes' );
 
 		// Join with postmeta to filter by _nt_preorder
-		$clauses['join'] .= " INNER JOIN {$wpdb->postmeta} AS nt_preorder_pm ON ({$wpdb->posts}.ID = nt_preorder_pm.post_id AND nt_preorder_pm.meta_key = '{$meta_key}') ";
-		$clauses['where'] .= " AND nt_preorder_pm.meta_value = '{$meta_value}' ";
+		$clauses['join'] .= $wpdb->prepare(
+			" LEFT JOIN {$wpdb->postmeta} AS nt_preorder_pm ON ({$wpdb->posts}.ID = nt_preorder_pm.post_id AND nt_preorder_pm.meta_key = %s) ",
+			'_nt_preorder'
+		);
+		$clauses['where'] .= $wpdb->prepare(
+			" AND nt_preorder_pm.meta_value = %s ",
+			'yes'
+		);
 
 		return $clauses;
 	}

--- a/src/Product.php
+++ b/src/Product.php
@@ -95,8 +95,14 @@ class Product {
 		global $wpdb;
 
 		// Join with postmeta to filter by _nt_preorder
-		$clauses['join'] .= " LEFT JOIN {$wpdb->postmeta} AS nt_preorder_pm ON ({$wpdb->posts}.ID = nt_preorder_pm.post_id AND nt_preorder_pm.meta_key = '_nt_preorder') ";
-		$clauses['where'] .= " AND nt_preorder_pm.meta_value = 'yes' ";
+		$clauses['join'] .= $wpdb->prepare(
+			" LEFT JOIN {$wpdb->postmeta} AS nt_preorder_pm ON ({$wpdb->posts}.ID = nt_preorder_pm.post_id AND nt_preorder_pm.meta_key = %s) ",
+			'_nt_preorder'
+		);
+		$clauses['where'] .= $wpdb->prepare(
+			" AND nt_preorder_pm.meta_value = %s ",
+			'yes'
+		);
 
 		return $clauses;
 	}

--- a/src/Product.php
+++ b/src/Product.php
@@ -40,6 +40,7 @@ class Product {
 		add_filter( 'the_title', [ $this, 'nt_preorder_title' ], 10, 2 );
 		add_filter( 'woocommerce_cart_item_name', [ $this, 'nt_preorder_title' ], 10, 2 );
 		add_filter( 'woocommerce_order_item_get_name', [ $this, 'nt_preorder_title' ], 10, 2 );
+		add_filter( 'posts_search', [ $this, 'filter_preorder_posts_search' ], 10, 2 );
 		add_filter( 'posts_clauses', [ $this, 'modify_preorder_posts_clauses' ], 10, 2 );
 	}
 
@@ -88,30 +89,32 @@ class Product {
 	 * @return array
 	 */
 	public function modify_preorder_posts_clauses( array $clauses, WP_Query $query ): array {
-		if ( is_admin() || ! $query->is_main_query() || ! is_post_type_archive( 'product' ) ) {
+		if ( ! $this->should_filter_preorder_search( $query ) ) {
 			return $clauses;
 		}
+		global $wpdb;
 
-		$search_query = $query->get( 's' );
-
-		if ( empty( $search_query ) ) {
-			return $clauses;
-		}
-
-		$search_terms = $this->get_preorder_search_terms();
-
-		if ( in_array( strtolower( trim( $search_query ) ), $search_terms, true ) ) {
-			global $wpdb;
-
-			// Join with postmeta to filter by _nt_preorder
-			$clauses['join'] .= " LEFT JOIN {$wpdb->postmeta} AS nt_preorder_pm ON ({$wpdb->posts}.ID = nt_preorder_pm.post_id AND nt_preorder_pm.meta_key = '_nt_preorder') ";
-
-			// Force the where clause to only include preorder products and ignore the standard search 's' for where clause
-			// We keep 's' in the query object so breadcrumbs and titles work automatically
-			$clauses['where'] .= " OR nt_preorder_pm.meta_value = 'yes' ";
-		}
+		// Join with postmeta to filter by _nt_preorder
+		$clauses['join'] .= " LEFT JOIN {$wpdb->postmeta} AS nt_preorder_pm ON ({$wpdb->posts}.ID = nt_preorder_pm.post_id AND nt_preorder_pm.meta_key = '_nt_preorder') ";
+		$clauses['where'] .= " AND nt_preorder_pm.meta_value = 'yes' ";
 
 		return $clauses;
+	}
+
+	/**
+	 * Removes the default search SQL when the preorder search terms are used.
+	 *
+	 * @param string $search
+	 * @param WP_Query $query
+	 *
+	 * @return string
+	 */
+	public function filter_preorder_posts_search( string $search, WP_Query $query ): string {
+		if ( $this->should_filter_preorder_search( $query ) ) {
+			return '';
+		}
+
+		return $search;
 	}
 
 	/**
@@ -142,5 +145,26 @@ class Product {
 		}
 
 		return array_unique( $terms );
+	}
+
+	/**
+	 * Checks if the current query should return preorder products for the search term.
+	 *
+	 * @param WP_Query $query
+	 *
+	 * @return bool
+	 */
+	protected function should_filter_preorder_search( WP_Query $query ): bool {
+		if ( is_admin() || ! $query->is_main_query() || ! is_post_type_archive( 'product' ) ) {
+			return false;
+		}
+
+		$search_query = trim( (string) $query->get( 's' ) );
+
+		if ( $search_query === '' ) {
+			return false;
+		}
+
+		return in_array( strtolower( $search_query ), $this->get_preorder_search_terms(), true );
 	}
 }

--- a/tests/Admin/SettingsTest.php
+++ b/tests/Admin/SettingsTest.php
@@ -35,9 +35,10 @@ class SettingsTest extends TestCase {
 		$result = $settings->filter_woocommerce_get_settings_for_section( $original_settings, '_nt_manage_preorder' );
 
 		$this->assertNotEquals( $original_settings, $result );
-		$this->assertCount( 4, $result );
+		$this->assertCount( 5, $result );
 		$this->assertEquals( 'nt_preorder_settings', $result[0]['id'] );
 		$this->assertEquals( 'nt_preorder_text', $result[1]['id'] );
 		$this->assertEquals( 'nt_preorder_position', $result[2]['id'] );
+		$this->assertEquals( 'nt_preorder_search_terms', $result[3]['id'] );
 	}
 }

--- a/tests/ProductTest.php
+++ b/tests/ProductTest.php
@@ -70,6 +70,16 @@ class ProductTest extends TestCase {
 		$GLOBALS['wpdb']                        = new class() {
 			public string $postmeta = 'wp_postmeta';
 			public string $posts = 'wp_posts';
+
+			public function prepare( string $query, ...$args ): string {
+				return vsprintf(
+					$query,
+					array_map(
+						static fn( string $value ): string => "'" . $value . "'",
+						$args
+					)
+				);
+			}
 		};
 
 		$product = new Product();
@@ -81,7 +91,7 @@ class ProductTest extends TestCase {
 
 		$result = $product->modify_preorder_posts_clauses( $clauses, $query );
 
-		$this->assertStringContainsString( 'INNER JOIN wp_postmeta AS nt_preorder_pm', $result['join'] );
+		$this->assertStringContainsString( 'LEFT JOIN wp_postmeta AS nt_preorder_pm', $result['join'] );
 		$this->assertStringContainsString( "AND nt_preorder_pm.meta_value = 'yes'", $result['where'] );
 		$this->assertStringNotContainsString( "OR nt_preorder_pm.meta_value = 'yes'", $result['where'] );
 	}

--- a/tests/ProductTest.php
+++ b/tests/ProductTest.php
@@ -11,6 +11,8 @@ class ProductTest extends TestCase {
 	protected function tearDown(): void {
 		unset( $GLOBALS['post_meta_return'] );
 		unset( $GLOBALS['options_return'] );
+		unset( $GLOBALS['is_post_type_archive_return'] );
+		unset( $GLOBALS['wpdb'] );
 	}
 
 	public function test_nt_preorder_title_without_preorder() {
@@ -25,13 +27,13 @@ class ProductTest extends TestCase {
 	}
 
 	public function test_nt_preorder_title_with_preorder_before() {
-		$product = new Product();
-
 		$GLOBALS['post_meta_return'] = 'yes';
 		$GLOBALS['options_return']   = [
 			'nt_preorder_text'     => '[PREORDER]',
 			'nt_preorder_position' => 'before'
 		];
+
+		$product = new Product();
 
 		$title  = 'Sample Product';
 		$result = $product->nt_preorder_title( $title, 123 );
@@ -40,17 +42,47 @@ class ProductTest extends TestCase {
 	}
 
 	public function test_nt_preorder_title_with_preorder_after() {
-		$product = new Product();
-
 		$GLOBALS['post_meta_return'] = 'yes';
 		$GLOBALS['options_return']   = [
 			'nt_preorder_text'     => '[PREORDER]',
 			'nt_preorder_position' => 'after'
 		];
 
+		$product = new Product();
+
 		$title  = 'Sample Product';
 		$result = $product->nt_preorder_title( $title, 123 );
 
 		$this->assertEquals( 'Sample Product [PREORDER]', $result );
+	}
+
+	public function test_filter_preorder_posts_search_clears_matching_search_clause() {
+		$GLOBALS['is_post_type_archive_return'] = true;
+
+		$product = new Product();
+		$query   = new \WP_Query( [ 's' => 'preorder' ] );
+
+		$this->assertSame( '', $product->filter_preorder_posts_search( " AND ((wp_posts.post_title LIKE '%preorder%'))", $query ) );
+	}
+
+	public function test_modify_preorder_posts_clauses_adds_preorder_only_filter() {
+		$GLOBALS['is_post_type_archive_return'] = true;
+		$GLOBALS['wpdb']                        = (object) [
+			'postmeta' => 'wp_postmeta',
+			'posts'    => 'wp_posts',
+		];
+
+		$product = new Product();
+		$query   = new \WP_Query( [ 's' => 'preorder' ] );
+		$clauses = [
+			'join'  => '',
+			'where' => " AND wp_posts.post_type = 'product' ",
+		];
+
+		$result = $product->modify_preorder_posts_clauses( $clauses, $query );
+
+		$this->assertStringContainsString( 'LEFT JOIN wp_postmeta AS nt_preorder_pm', $result['join'] );
+		$this->assertStringContainsString( "AND nt_preorder_pm.meta_value = 'yes'", $result['where'] );
+		$this->assertStringNotContainsString( "OR nt_preorder_pm.meta_value = 'yes'", $result['where'] );
 	}
 }

--- a/tests/ProductTest.php
+++ b/tests/ProductTest.php
@@ -67,10 +67,20 @@ class ProductTest extends TestCase {
 
 	public function test_modify_preorder_posts_clauses_adds_preorder_only_filter() {
 		$GLOBALS['is_post_type_archive_return'] = true;
-		$GLOBALS['wpdb']                        = (object) [
-			'postmeta' => 'wp_postmeta',
-			'posts'    => 'wp_posts',
-		];
+		$GLOBALS['wpdb']                        = new class() {
+			public string $postmeta = 'wp_postmeta';
+			public string $posts = 'wp_posts';
+
+			public function prepare( string $query, ...$args ): string {
+				return vsprintf(
+					$query,
+					array_map(
+						static fn( string $value ): string => "'" . $value . "'",
+						$args
+					)
+				);
+			}
+		};
 
 		$product = new Product();
 		$query   = new \WP_Query( [ 's' => 'preorder' ] );

--- a/tests/ProductTest.php
+++ b/tests/ProductTest.php
@@ -70,16 +70,6 @@ class ProductTest extends TestCase {
 		$GLOBALS['wpdb']                        = new class() {
 			public string $postmeta = 'wp_postmeta';
 			public string $posts = 'wp_posts';
-
-			public function prepare( string $query, ...$args ): string {
-				return vsprintf(
-					$query,
-					array_map(
-						static fn( string $value ): string => "'" . $value . "'",
-						$args
-					)
-				);
-			}
 		};
 
 		$product = new Product();
@@ -91,7 +81,7 @@ class ProductTest extends TestCase {
 
 		$result = $product->modify_preorder_posts_clauses( $clauses, $query );
 
-		$this->assertStringContainsString( 'LEFT JOIN wp_postmeta AS nt_preorder_pm', $result['join'] );
+		$this->assertStringContainsString( 'INNER JOIN wp_postmeta AS nt_preorder_pm', $result['join'] );
 		$this->assertStringContainsString( "AND nt_preorder_pm.meta_value = 'yes'", $result['where'] );
 		$this->assertStringNotContainsString( "OR nt_preorder_pm.meta_value = 'yes'", $result['where'] );
 	}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -31,6 +31,12 @@ if ( ! function_exists( 'is_admin' ) ) {
 	}
 }
 
+if ( ! function_exists( 'is_post_type_archive' ) ) {
+	function is_post_type_archive( $post_type = '' ) {
+		return $GLOBALS['is_post_type_archive_return'] ?? false;
+	}
+}
+
 if ( ! function_exists( 'get_post_meta' ) ) {
 	function get_post_meta( $post_id, $key = '', $single = false ) {
 		return $GLOBALS['post_meta_return'] ?? '';
@@ -46,6 +52,26 @@ if ( ! function_exists( 'get_option' ) ) {
 if ( ! class_exists( 'WC_Product' ) ) {
 	class WC_Product {
 		public function update_meta_data( $key, $value ) {
+		}
+	}
+}
+
+if ( ! class_exists( 'WP_Query' ) ) {
+	class WP_Query {
+		private array $query_vars;
+		private bool $main_query;
+
+		public function __construct( array $query_vars = [], bool $main_query = true ) {
+			$this->query_vars = $query_vars;
+			$this->main_query = $main_query;
+		}
+
+		public function is_main_query(): bool {
+			return $this->main_query;
+		}
+
+		public function get( string $key ) {
+			return $this->query_vars[ $key ] ?? null;
 		}
 	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -49,6 +49,12 @@ if ( ! function_exists( 'get_option' ) ) {
 	}
 }
 
+if ( ! function_exists( 'esc_sql' ) ) {
+	function esc_sql( $data ) {
+		return $data;
+	}
+}
+
 if ( ! class_exists( 'WC_Product' ) ) {
 	class WC_Product {
 		public function update_meta_data( $key, $value ) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -49,12 +49,6 @@ if ( ! function_exists( 'get_option' ) ) {
 	}
 }
 
-if ( ! function_exists( 'esc_sql' ) ) {
-	function esc_sql( $data ) {
-		return $data;
-	}
-}
-
 if ( ! class_exists( 'WC_Product' ) ) {
 	class WC_Product {
 		public function update_meta_data( $key, $value ) {


### PR DESCRIPTION
This PR reverts commit `7549bfa`, which changed preorder SQL join handling. The intent is to restore the prior query-shaping behavior used by preorder product filtering.

- **Query clause behavior (restored)**
  - Reverts `modify_preorder_posts_clauses()` to the previous form:
    - `LEFT JOIN` on `postmeta` alias `nt_preorder_pm`
    - parameterized SQL fragments via `$wpdb->prepare(...)` for `_nt_preorder` and `yes`

- **Test alignment**
  - Updates preorder clause assertion back to `LEFT JOIN` in `tests/ProductTest.php`
  - Restores test `wpdb` mock support for `prepare(...)` used by the reverted implementation

- **Bootstrap cleanup (as part of revert)**
  - Removes the temporary `esc_sql()` shim from `tests/bootstrap.php` that was only needed by the reverted change

```php
$clauses['join'] .= $wpdb->prepare(
	" LEFT JOIN {$wpdb->postmeta} AS nt_preorder_pm ON ({$wpdb->posts}.ID = nt_preorder_pm.post_id AND nt_preorder_pm.meta_key = %s) ",
	'_nt_preorder'
);
$clauses['where'] .= $wpdb->prepare(
	" AND nt_preorder_pm.meta_value = %s ",
	'yes'
);
```